### PR TITLE
Link miniforge instead of anaconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A sandbox repository containing instructions and notebooks to train, evaluate, a
 
 ## 🛠️ Setup Environment
 
-Download a Python package manager like [Anaconda](https://www.anaconda.com/).
+Download and install miniforge[miniforge](https://github.com/conda-forge/miniforge), a minimal install for Conda and Mamba specific to conda-forge.
 
 Create the environment:
 


### PR DESCRIPTION
Anaconda must be avoided for licensing issues, see also internal guidelines in https://meteoswiss.atlassian.net/wiki/spaces/PYTHONMCH/pages/17270951/Python+CSCS#Installing-and-using-Conda%2FMamba